### PR TITLE
Update zfs

### DIFF
--- a/provisioners/zfs
+++ b/provisioners/zfs
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash -eux
 # Use the first disk not assigned to a zpool already to create the data pool.
-for DISK in $(cfgadm -al | awk -F\/ '/dsk/{ print $3 }' | awk '{ print $1 }'); do
-  if [[ -z $(zpool list -v | ggrep -E '^\s+${DISK}') ]]; then
+for DISK in $(diskinfo -H | awk '{ print $2 }')
+do
+  echo "Checking ${DISK}"
+  if [[ -z $(zpool list -H -v | egrep -e '^[[:blank:]]*'"${DISK}") ]]
+  then
+    echo "Found ${DISK}"
     echo "[II] Adding data zpool using whole disk ${DISK}"
     pfexec zpool create -f tank ${DISK}
     break


### PR DESCRIPTION
The command `cfgadm` does not show disks in OmniOS 151038 VM but only usb related devices.
```
$>cfgadm -al
Ap_Id                          Type         Receptacle   Occupant     Condition
usb1/1                         usb-input    connected    configured   ok
usb1/2                         unknown      empty        unconfigured ok
```
Diskinfo does show a list of disks.
```
$>diskinfo
TYPE    DISK                    VID      PID              SIZE          RMV SSD
-       c2t0d0                  Virtio   Block Device       16.00 GiB   no  no
-       c4t0d0                  Virtio   Block Device       64.00 GiB   no  no
```
Single quotes prevents expansion. '${DISK}' will still be '${DISK}', not an actual disk name.